### PR TITLE
Narrow XML XPath scopes for more focused reported violations

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -84,7 +84,7 @@
             <property name="version" value="2.0"></property>
             <property name="xpath">
                 <value><![CDATA[
-                //SecuritySettings[ passwordPolicies/complexity/text[@Image='No restriction'] ]
+                //SecuritySettings/passwordPolicies/complexity[ text[@Image='No restriction'] ]
                 ]]> </value>
             </property>
         </properties>
@@ -96,7 +96,7 @@
             <property name="version" value="2.0"></property>
             <property name="xpath">
                 <value><![CDATA[
-                //SecuritySettings[ passwordPolicies/minimumPasswordLength/text[@Image<'8'] ]
+                //SecuritySettings/passwordPolicies/minimumPasswordLength[ text[@Image<'8'] ]
                 ]]> </value>
             </property>
         </properties>
@@ -108,7 +108,7 @@
             <property name="version" value="2.0"></property>
             <property name="xpath">
                 <value><![CDATA[
-                //Profile[ (userPermissions/name/text[@Image='ModifyAllData'] or userPermissions/name/text[@Image='ViewAllData']) and pmd:fileName()!='System Administrator' and userPermissions/enabled/text[@Image='true'] ]
+                //Profile/userPermissions[ name/text[@Image='ModifyAllData' or @Image='ViewAllData'] and enabled/text[@Image='true'] and pmd:fileName() != 'System Administrator' ]
                 ]]> </value>
             </property>
         </properties>
@@ -120,7 +120,7 @@
             <property name="version" value="2.0"></property>
             <property name="xpath">
                 <value><![CDATA[
-                //PermissionSet[ userPermissions/name/text[@Image='ModifyAllData'] and userPermissions/enabled/text[@Image='true'] ]
+                //PermissionSet/userPermissions[ name/text[@Image='ModifyAllData'] and enabled/text[@Image='true'] ]
                 ]]> </value>
             </property>
         </properties>
@@ -132,7 +132,7 @@
             <property name="version" value="2.0"></property>
             <property name="xpath">
                 <value><![CDATA[
-                //PermissionSet[ userPermissions/name/text[@Image='ViewAllData'] and userPermissions/enabled/text[@Image='true'] ]
+                //PermissionSet/userPermissions[ name/text[@Image='ViewAllData'] and enabled/text[@Image='true'] ]
                 ]]> </value>
             </property>
         </properties>
@@ -144,7 +144,7 @@
             <property name="version" value="2.0"></property>
             <property name="xpath">
                 <value><![CDATA[
-                //Profile[ pmd:fileName()!='System Administrator' and userPermissions/name/text[@Image='ManageUsers'] ]
+                //Profile/userPermissions[ pmd:fileName() != 'System Administrator' and name/text[@Image='ManageUsers'] ]
                 ]]> </value>
             </property>
         </properties>
@@ -156,7 +156,7 @@
             <property name="version" value="2.0"></property>
             <property name="xpath">
                 <value><![CDATA[
-                //SecuritySettings[ sessionSettings/sessionTimeout/text[@Image='24 hours of inactivity'] or sessionSettings/sessionTimeout/text[@Image='12 hours of inactivity'] ]
+                //SecuritySettings/sessionTimeout[ text[@Image='24 hours of inactivity'] or text[@Image='12 hours of inactivity'] ]
                 ]]> </value>
             </property>
         </properties>
@@ -168,7 +168,7 @@
             <property name="version" value="2.0"></property>
             <property name="xpath">
                 <value><![CDATA[
-                //SecuritySettings[ passwordPolicies/expiration/text[@Image='Never'] or passwordPolicies/expiration/text[@Image='SixMonths'] or passwordPolicies/expiration/text[@Image='OneYear'] ]
+                //SecuritySettings/passwordPolicies/expiration[ text[@Image='Never'] or text[@Image='SixMonths'] or text[@Image='OneYear'] ]
                 ]]> </value>
             </property>
         </properties>
@@ -180,7 +180,7 @@
             <property name="version" value="2.0"></property>
             <property name="xpath">
                 <value><![CDATA[
-                //Profile[ pmd:fileName()!='System Administrator' and userPermissions/enabled/text[@Image='true'] and userPermissions/name/text[@Image='ViewSetup'] ]
+                //Profile/userPermissions[ pmd:fileName() != 'System Administrator' and enabled/text[@Image='true'] and name/text[@Image='ViewSetup'] ]
                 ]]> </value>
             </property>
         </properties>


### PR DESCRIPTION
Hey, @rsoesemann. I recently updated IC2's real-time PMD integration to include support for XML rules as well based on the great work you (and others?) did here. One thing I noticed immediately is that violations in XML files were being attributed to the entire root XML element, e.g., `PermissionSet`, `Profile`, and SecuritySettings`, instead of the specific elements in which the violations occurred. I modified the XPath rule definitions to select the most specific offending elements which results in a much more focused report, whether in an IDE integration or externalized as HTML, console text, etc. These are the resulting changes if you wanted to integrate them into your core repository and/or propagate them to other locations that document this approach for verifying Salesforce XML-based metadata.